### PR TITLE
Improve signup flow for early access to Khoj cloud

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import NavBar from './NavBar';
 import './styles/App.css';
 import Home from './pages/Home';
 import About from './pages/About';
-import Waitlist from './pages/Waitlist';
+import Waitlist from './components/Waitlist';
 
 import { ConfigProvider } from 'antd';
 

--- a/src/NavBar.tsx
+++ b/src/NavBar.tsx
@@ -1,11 +1,13 @@
 import { Link, Outlet } from "react-router-dom";
 import './styles/NavBar.css';
 import { Button } from 'antd';
+import Waitlist from "./components/Waitlist";
 
 export default function NavBar() {
     return (
         <nav className="navBar">
             <section className="navSection">
+                <Waitlist />
                 <div className="navLogo">
                     <Link to="/">
                         <img className='khoj-logo' src="https://raw.githubusercontent.com/khoj-ai/landing-page/master/public/khoj_lantern_logo.svg" alt="Khoj" />

--- a/src/NavBar.tsx
+++ b/src/NavBar.tsx
@@ -22,11 +22,6 @@ export default function NavBar() {
                         }>
                             <Link className="navLinks" to="/about">About</Link>
                         </Button>
-                        <Button type="text" size="large" shape="default" style={
-                            {borderRadius: '4px', border: '1px solid #000', backgroundColor: '#f9f5de'}
-                        }>
-                            <Link className="navLinks" to="/waitlist">Waitlist</Link>
-                        </Button>
                     </div>
                     <div></div>
                 </div>

--- a/src/NavBar.tsx
+++ b/src/NavBar.tsx
@@ -16,8 +16,10 @@ export default function NavBar() {
                 <div className="navContent">
                     <div></div>
                     <div className="centeredLinks">
-                        <Button type="primary" size="large" shape="default" style={{borderRadius: '4px'}}>
-                            <Link className="navLinks" to="https://github.com/debanjum/khoj#Setup">Install</Link>
+                        <Button size="large" shape="default" style={
+                            {borderRadius: '4px', border: '1px solid #000', backgroundColor: '#f9f5de'}
+                        }>
+                            <Link className="navLinks" to="https://github.com/debanjum/khoj#Setup">Self Host</Link>
                         </Button>
                         <Button type="text" size="large" shape="default" style={
                             {borderRadius: '4px', border: '1px solid #000', backgroundColor: '#f9f5de'}

--- a/src/components/Waitlist.tsx
+++ b/src/components/Waitlist.tsx
@@ -2,7 +2,7 @@ import '../styles/Waitlist.css';
 
 import { Form, Formik } from 'formik';
 import * as Yup from 'yup';
-import { Input, SubmitButton, Select } from 'formik-antd'
+import { Input, SubmitButton } from 'formik-antd'
 import { useState } from 'react';
 
 
@@ -16,9 +16,7 @@ export function Waitlist() {
 	const APIURL = process.env.NODE_ENV == 'production' ? "https://lantern.khoj.dev" : 'http://localhost:5000';
 
 	return (
-		<section className='core-page'>
-			<h2 className='title'>Join the Waitlist</h2>
-			<div className='waitlist-form'>
+			<div className='signup-bar'>
 				<Formik
 					initialValues={{ email: '', interest: '' }}
 					validationSchema={SignupSchema}
@@ -59,41 +57,23 @@ export function Waitlist() {
 						isSubmitting,
 						/* and other goodies */
 					}) => (
-						<Form className='waitlist-form'>
-							<Input
-								className='waitlist'
-								placeholder="input email"
-								type="email"
-								name="email"
-								onChange={handleChange}
-								onBlur={handleBlur}
-								value={values.email}
-								status={(errors.email && touched.email) ? "error" : ""}
-								addonBefore="Email"
-							/>
-							<label className='waitlist'>
-								Which of the following best describes your industry?
-							</label>
-							<Select 
-								name="interest"
-								placeholder="What's your area of interest?"
-								onChange={handleChange}
-								onBlur={handleBlur}
-								value={values.interest}
-							>
-								<Select.Option value="Art">Art</Select.Option>
-								<Select.Option value="Business">Business</Select.Option>
-								<Select.Option value="Education">Education</Select.Option>
-								<Select.Option value="Health">Health</Select.Option>
-								<Select.Option value="Science">Science</Select.Option>
-								<Select.Option value="Technology">Technology</Select.Option>
-								<Select.Option value="Research">Research</Select.Option>
-								<Select.Option value="Other">Other</Select.Option>
-							</Select>
-							<SubmitButton disabled={false} loading={isSubmitting}>
-								Submit
-							</SubmitButton>
-						</Form>
+						<div className='signup-bar'>
+							<p className="signup-description">Sign up to get an early invite to Khoj cloud</p>
+							<Form className='signup-form'>
+								<Input
+									type="email"
+									name="email"
+									placeholder="Enter your email address"
+									onChange={handleChange}
+									onBlur={handleBlur}
+									value={values.email}
+									status={(errors.email && touched.email) ? "error" : ""}
+								/>
+								<SubmitButton size='large' disabled={false} loading={isSubmitting} style={{padding: '5px 10px'}}>
+									Sign up
+								</SubmitButton>
+							</Form>
+						</div>
 					)}
 				</Formik>
 				{
@@ -103,7 +83,6 @@ export function Waitlist() {
 					failed ? <p>Sorry, something went wrong. Please try again.</p> : null
 				}
 			</div>
-		</section>
 	);
 }
 

--- a/src/components/Waitlist.tsx
+++ b/src/components/Waitlist.tsx
@@ -16,7 +16,7 @@ export function Waitlist() {
 	const APIURL = process.env.NODE_ENV == 'production' ? "https://lantern.khoj.dev" : 'http://localhost:5000';
 
 	return (
-			<div className='signup-bar'>
+			<div className='waitlist-bar'>
 				<Formik
 					initialValues={{ email: '', interest: '' }}
 					validationSchema={SignupSchema}
@@ -34,7 +34,7 @@ export function Waitlist() {
 									if (!response.ok) {
 										setFailed(true);
 										setSuccess(false);
-										throw new Error('Network response was not ok');
+										throw new Error('📵 Network response was not ok');
 									}
 									setSuccess(true);
 									setFailed(false);
@@ -57,11 +57,11 @@ export function Waitlist() {
 						isSubmitting,
 						/* and other goodies */
 					}) => (
-						<div className="signup-spacer">
+						<div className="waitlist-spacer">
 							<div></div>
-							<div className='signup-inner-bar'>
-								<p className="signup-description">Sign up to get an early invite to Khoj cloud</p>
-								<Form className='signup-form'>
+							<div className='waitlist-inner-bar'>
+								<p className="waitlist-description">Sign up to get an early invite to Khoj cloud</p>
+								<Form className='waitlist-form'>
 									<Input
 										type="email"
 										name="email"

--- a/src/components/Waitlist.tsx
+++ b/src/components/Waitlist.tsx
@@ -57,22 +57,26 @@ export function Waitlist() {
 						isSubmitting,
 						/* and other goodies */
 					}) => (
-						<div className='signup-bar'>
-							<p className="signup-description">Sign up to get an early invite to Khoj cloud</p>
-							<Form className='signup-form'>
-								<Input
-									type="email"
-									name="email"
-									placeholder="Enter your email address"
-									onChange={handleChange}
-									onBlur={handleBlur}
-									value={values.email}
-									status={(errors.email && touched.email) ? "error" : ""}
-								/>
-								<SubmitButton size='large' disabled={false} loading={isSubmitting} style={{padding: '5px 10px'}}>
-									Sign up
-								</SubmitButton>
-							</Form>
+						<div className="signup-spacer">
+							<div></div>
+							<div className='signup-inner-bar'>
+								<p className="signup-description">Sign up to get an early invite to Khoj cloud</p>
+								<Form className='signup-form'>
+									<Input
+										type="email"
+										name="email"
+										placeholder="Enter your email address"
+										onChange={handleChange}
+										onBlur={handleBlur}
+										value={values.email}
+										status={(errors.email && touched.email) ? "error" : ""}
+									/>
+									<SubmitButton size='large' disabled={false} loading={isSubmitting} style={{padding: '9px'}}>
+										Sign up
+									</SubmitButton>
+								</Form>
+							</div>
+							<div></div>
 						</div>
 					)}
 				</Formik>

--- a/src/components/Waitlist.tsx
+++ b/src/components/Waitlist.tsx
@@ -81,10 +81,10 @@ export function Waitlist() {
 					)}
 				</Formik>
 				{
-					success ? <p>Thank you for joining the waitlist!</p> : null
+					success ? <p>Thanks for requesting early access 🌈! We'll reach out shortly. Until then take this short <a href="https://forms.gle/FRe6XPkcgkKsVbzC9">survey</a> to guide our feature development roadmap.</p> : null
 				}
 				{
-					failed ? <p>Sorry, something went wrong. Please try again.</p> : null
+					failed ? <p>Woops, that did not go as expected 😵‍💫. Try again or contact <a href="mailto:team@khoj.dev">team@khoj.dev</a></p> : null
 				}
 			</div>
 	);

--- a/src/components/Waitlist.tsx
+++ b/src/components/Waitlist.tsx
@@ -72,7 +72,7 @@ export function Waitlist() {
 										status={(errors.email && touched.email) ? "error" : ""}
 									/>
 									<SubmitButton size='large' disabled={false} loading={isSubmitting} style={{padding: '9px'}}>
-										Sign up
+										Join
 									</SubmitButton>
 								</Form>
 							</div>

--- a/src/components/Waitlist.tsx
+++ b/src/components/Waitlist.tsx
@@ -60,7 +60,7 @@ export function Waitlist() {
 						<div className="waitlist-spacer">
 							<div></div>
 							<div className='waitlist-inner-bar'>
-								<p className="waitlist-description">Sign up to get an early invite to Khoj cloud</p>
+								<p className="waitlist-description">Get an early invite to Khoj cloud</p>
 								<Form className='waitlist-form'>
 									<Input
 										type="email"

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -41,14 +41,24 @@ export default function About() {
                         <h2 className='article-title'>Why we're making it</h2>
                         <div className='content'>
                             <p className='content'>
+                                <b>We're on a mission to democratize access to these tools</b>, so that the productivity gains from these advances are available to the most diverse range of people possible without giving up your privacy.
+                                Given what is at stake, there is no reason to settle for anything less.
+                            </p>
+                            <p className='content'>
                                 We've seen zetabytes of data moving online over the last 3-4 decades.
                                 But the tools to access and use this data have not kept up, especially for personal data.
                                 The current wave of AI innovations are creating tools that will vastly improve the ability of people to use this data.
                                 We have the opportunity to guide this wave of innovation.
                             </p>
                             <p className='content'>
-                                <b>We're on a mission to democratize access to these tools</b>, so that the productivity gains from these advances are available to the most diverse range of people possible without giving up your privacy.
-                                Given what is at stake, there is no reason to settle for anything less.
+                                As the ongoing information revolution accelerates, finding ways to work with the exploding quantities of data will be paramount.
+                            </p>
+                            <p className='content'>
+                                Khoj is designed to be that way.
+                            </p>
+                            <p className='content'>
+                                Khoj is <b>your</b> personal AI assistant.
+                                It's a thinking tool for your daily life. It will allow you to create, reason and build faster and better.
                             </p>
                         </div>
                         <h2 className='article-title'>Get in touch</h2>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -23,7 +23,6 @@ export function Home() {
 
 	return (
 		<section className='core-page'>
-			<Waitlist />
 			<h2 className='title'>Introducing Khoj</h2>
 			<div className='product-description'>
 				<div className="product-description-text">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -22,6 +22,13 @@ export function Home() {
 
 	return (
 		<section className='core-page'>
+			<div className="signup-bar">
+			<p className="signup-description">Sign up to get an early invite to Khoj cloud</p>
+			<form className="signup-form">
+				<input type="email" name="email" placeholder="Enter your email address" required />
+				<button type="submit">Sign up</button>
+			</form>
+			</div>
 			<h2 className='title'>Introducing Khoj</h2>
 			<div className='product-description'>
 				<div className="product-description-text">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import { useState, useRef } from 'react';
 import { Button } from 'antd';
 import { Link } from "react-router-dom";
 import { GithubIcon, DiscordIcon, EmacsIcon, ObsidianIcon } from '../components/Icons';
+import Waitlist from '../components/Waitlist';
 import Icon from '@ant-design/icons';
 
 export function Home() {
@@ -22,13 +23,7 @@ export function Home() {
 
 	return (
 		<section className='core-page'>
-			<div className="signup-bar">
-			<p className="signup-description">Sign up to get an early invite to Khoj cloud</p>
-			<form className="signup-form">
-				<input type="email" name="email" placeholder="Enter your email address" required />
-				<button type="submit">Sign up</button>
-			</form>
-			</div>
+			<Waitlist />
 			<h2 className='title'>Introducing Khoj</h2>
 			<div className='product-description'>
 				<div className="product-description-text">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -27,7 +27,7 @@ export function Home() {
 			<div className='product-description'>
 				<div className="product-description-text">
 					<p id="app-subtitle" className="product-description">
-						An AI personal assistant for your digital brain
+						An <b>open source</b> AI personal assistant for your digital brain.
 					</p>
 				</div>
 				<video
@@ -71,24 +71,31 @@ export function Home() {
 					<img src='https://raw.githubusercontent.com/khoj-ai/landing-page/master/public/hero_camping.svg' className='hero-camping' alt='hero-camping' />
 				</div>
 			</div>
-			<div id="mission" className='camping-block'>
-				<div className="product-description">
-					<div className='production-description-subcomponent camping-description-subcomponent'>
-						<h2 className='production-description-subcomponent'>Our mission</h2>
-						<p className='product-description-subcomponent'>
-							Our mission is to democratize access to AI assistance.
-							As the ongoing information revolution accelerates, finding ways to work with the exploding quantities of data will be paramount.
-						</p>
-						<p className='product-description-subcomponent'>
-							Khoj is designed to be that way.
-						</p>
-						<p className='product-description-subcomponent'>
-							Khoj is <b>your</b> personal AI assistant.
-							It's a thinking tool for your daily life. It will allow you to create, reason and build faster and better.
-						</p>
+			<section id="mission">
+				<div id="mission" className='camping-block'>
+					<div className="product-description">
+						<div className='production-description-subcomponent camping-description-subcomponent'>
+							<h2 className='production-description-subcomponent'>What is Khoj?</h2>
+							<p className='product-description-subcomponent-light'>
+								Khoj is an AI personal assistant that is designed with the intention of keeping you in control of your data. It works by connecting to your personal knowledge base and exposing interfaces to search and chat. You can give and revoke Khoj's access to your data at any time. We see Khoj as a tool that can help you build a digital brain that is an extension of your own. Imagine being able to chat with your notes, documents, images, email, and far more.
+							</p>
+							<p className='product-description-subcomponent-light'>
+								Khoj started with the founding principle that it should be hostable on your own server. This means that it's completely private and personal, and that will always be the case.
+							</p>
+							<p className='product-description-subcomponent-light'>
+								But we've heard the feedback, and we know that self-hosting is a blocker for several people who want to try Khoj. Managing servers and developer dependencies is tricky. We're working on a hosted version of Khoj that will be available for personal use. If you're interested in trying out Khoj on the cloud, please sign up for early access below.
+							</p>
+							<p className='product-description-subcomponent-light'>
+								We're also working on creating a desktop application that will make installation as easy as clicking a button and running the application. This will eventually help people who want to self-host Khoj, but (like any sane person) don't want to deal with the hassle of managing their Python versions and dependencies.
+							</p>
+							<p className='product-description-subcomponent-light'>
+								<b>We're in the thick of building and improving Khoj, and we want to hear from you.</b> Please join the <a className='inline-link-light' href="https://discord.gg/fP89zSJb">Discord</a> to voice your opinions and tell us about which features you'd like to see.
+							</p>
+							<Waitlist />
+						</div>
 					</div>
 				</div>
-			</div>
+			</section>
 			<div id="chat" className='product-description'>
 				<div className='production-description-subcomponent-light'>
 					<h2 className='production-description-subcomponent'>Chat</h2>
@@ -112,7 +119,7 @@ export function Home() {
 				<div className='production-description-subcomponent'>
 					<h2 className='production-description-subcomponent'>Search</h2>
 					<p className='product-description-subcomponent-light'>
-						Khoj supports lightning fast search, with results from your data sources appearing as you type. It generates embeddings that allow you to perform semantic search on your data. This means that you can search for things that are similar to what you're looking for, not just exact matches. This data never leaves your server.
+						Khoj supports lightning fast search, with results from your data sources appearing as you type. It generates embeddings that allow you to perform semantic search on your data. This means that you can search for things that are similar to what you're looking for, rather than exact or fuzzy matches. In the self-hosted version, this data never leaves your server.
 					</p>
 					<video
 						id="demo-video"
@@ -165,7 +172,7 @@ export function Home() {
 						We plan to fix this by making information from your chosen data sources accessible to you in a private and secure way.
 					</p>
 					<p className='product-description-subcomponent-light'>
-						To learn more about the product, check out our <Link className='inline-link-light' to="/about">about page</Link>.
+						To learn more about the product, <Link className='inline-link-light' to="/about">click here</Link>.
 					</p>
 				</div>
 			</div>

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -98,4 +98,8 @@ a.inline-link-light {
   section.core-page {
     margin: 0;
   }
+
+  img.footer-garden {
+    padding: 0;
+  }
 }

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -1,5 +1,52 @@
 @import 'colors.css';
 
+.signup-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    background-color: rgba(205, 205, 205, 0.7);
+    padding: 0px;
+    margin: 0px;
+    box-sizing: border-box;
+    z-index: 9999;
+    display: grid;
+    grid-template-columns: 70% 30%;
+    align-items: center;
+}
+
+.signup-description {
+  margin: 0;
+  font-size: larger;
+}
+
+.signup-form {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  margin: 10px 0;
+}
+
+.signup-form input[type="email"] {
+  padding: 10px;
+  border: none;
+  border-radius: 3px;
+  font-size: medium;
+  grid-column: 1 / -2;
+}
+
+.signup-form button[type="submit"] {
+  padding: 10px 10px;
+  margin: 0 30px;
+  border: none;
+  border-radius: 3px;
+  background-color: var(--main-background);
+  color: #fff;
+  font-size: medium;
+  font-weight: bold;
+  cursor: pointer;
+}
+
 div.camping-block {
     background-color: var(--mild-sun);
 }

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -1,52 +1,5 @@
 @import 'colors.css';
 
-.signup-bar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    background-color: rgba(205, 205, 205, 0.7);
-    padding: 0px;
-    margin: 0px;
-    box-sizing: border-box;
-    z-index: 9999;
-    display: grid;
-    grid-template-columns: 70% 30%;
-    align-items: center;
-}
-
-.signup-description {
-  margin: 0;
-  font-size: larger;
-}
-
-.signup-form {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  align-items: center;
-  margin: 10px 0;
-}
-
-.signup-form input[type="email"] {
-  padding: 10px;
-  border: none;
-  border-radius: 3px;
-  font-size: medium;
-  grid-column: 1 / -2;
-}
-
-.signup-form button[type="submit"] {
-  padding: 10px 10px;
-  margin: 0 30px;
-  border: none;
-  border-radius: 3px;
-  background-color: var(--main-background);
-  color: #fff;
-  font-size: medium;
-  font-weight: bold;
-  cursor: pointer;
-}
-
 div.camping-block {
     background-color: var(--mild-sun);
 }

--- a/src/styles/NavBar.css
+++ b/src/styles/NavBar.css
@@ -14,7 +14,7 @@ section.navSection {
 }
 .centeredLinks {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-auto-flow: column;
     gap: 12px;
     justify-self: center;
 }

--- a/src/styles/NavBar.css
+++ b/src/styles/NavBar.css
@@ -37,7 +37,7 @@ a.navLinksFocus {
 div.navLogo {
     display: grid;
     justify-items: center;
-    padding-top: 30px;
+    padding-top: 70px;
     padding-bottom: 20px;
 }
 

--- a/src/styles/NavBar.css
+++ b/src/styles/NavBar.css
@@ -2,7 +2,6 @@
 
 section.navSection {
     display: grid;
-    grid-template-columns: repeat(1, 1fr);
     grid-auto-flow: row;
 }
 
@@ -58,7 +57,14 @@ li.navLinks {
         grid-template-columns: repeat(1, 1fr);
         grid-auto-flow: row;
     }
-    ul.navLinks {
+    div.navLogo {
+        display: grid;
+        justify-items: center;
+        padding-top: 100px;
+        padding-bottom: 20px;
+    }
+
+   ul.navLinks {
         display: grid;
         grid-template-columns: 1fr;
     }

--- a/src/styles/NavBar.css
+++ b/src/styles/NavBar.css
@@ -36,7 +36,7 @@ a.navLinksFocus {
 div.navLogo {
     display: grid;
     justify-items: center;
-    padding-top: 70px;
+    padding-top: 20px;
     padding-bottom: 20px;
 }
 
@@ -56,12 +56,6 @@ li.navLinks {
         display: grid;
         grid-template-columns: repeat(1, 1fr);
         grid-auto-flow: row;
-    }
-    div.navLogo {
-        display: grid;
-        justify-items: center;
-        padding-top: 100px;
-        padding-bottom: 20px;
     }
 
    ul.navLinks {

--- a/src/styles/Waitlist.css
+++ b/src/styles/Waitlist.css
@@ -1,23 +1,48 @@
 @import url(colors.css);
 
-div.waitlist-form {
-    margin-left: 40%;
-    margin-right: 40%;
-}
-
-form.waitlist-form {
+.signup-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    background-color: rgba(205, 205, 205, 0.7);
+    padding: 0px;
+    margin: 0px;
+    box-sizing: border-box;
+    z-index: 9999;
     display: grid;
-    grid-template-columns: 1fr;
-    grid-gap: 1rem;
+    grid-template-columns: 70% 30%;
+    align-items: center;
 }
 
-label.waitlist {
-    text-align: left;
+.signup-description {
+  margin: 0;
+  font-size: larger;
 }
 
-@media screen and (max-width: 760px) {
-    div.waitlist-form {
-        margin-left: 1rem;
-        margin-right: 1rem;
-    }
+.signup-form {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  margin: 10px 0;
+}
+
+.signup-form input[type="email"] {
+  padding: 10px;
+  border: none;
+  border-radius: 3px;
+  font-size: medium;
+  grid-column: 1 / -2;
+}
+
+.signup-form button[type="submit"] {
+  padding: 10px 10px;
+  margin: 0 30px;
+  border: none;
+  border-radius: 3px;
+  background-color: var(--main-background);
+  color: #fff;
+  font-size: medium;
+  font-weight: bold;
+  cursor: pointer;
 }

--- a/src/styles/Waitlist.css
+++ b/src/styles/Waitlist.css
@@ -1,9 +1,7 @@
 @import url(colors.css);
 
 .waitlist-bar {
-    position: fixed;
-    top: 0;
-    left: 0;
+    position: relative;
     width: 100%;
     background-color: rgba(205, 205, 205, 0.7);
     padding: 0px;
@@ -22,7 +20,7 @@
     gap: 50px;
     justify-self: center;
     align-items: center;
-    margin: 10px 0;
+    margin: 10px 10px;
 }
 .waitlist-description {
   margin: 0;
@@ -62,6 +60,6 @@
         gap: 10px;
         justify-self: center;
         align-items: center;
-        margin: 10px 0;
+        margin: 10px 10px;
     }
 }

--- a/src/styles/Waitlist.css
+++ b/src/styles/Waitlist.css
@@ -10,11 +10,20 @@
     margin: 0px;
     box-sizing: border-box;
     z-index: 9999;
-    display: grid;
-    grid-template-columns: 70% 30%;
-    align-items: center;
 }
-
+.signup-spacer {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    justify-items: center;
+ }
+.signup-inner-bar {
+    display: grid;
+    grid-auto-flow: column;
+    gap: 50px;
+    justify-self: center;
+    align-items: center;
+    margin: 10px 0;
+}
 .signup-description {
   margin: 0;
   font-size: larger;
@@ -24,20 +33,19 @@
   display: grid;
   grid-template-columns: 1fr auto;
   align-items: center;
-  margin: 10px 0;
+  margin: 0;
 }
 
 .signup-form input[type="email"] {
+  min-width: 200px;
   padding: 10px;
   border: none;
   border-radius: 3px;
   font-size: medium;
-  grid-column: 1 / -2;
 }
 
 .signup-form button[type="submit"] {
-  padding: 10px 10px;
-  margin: 0 30px;
+  margin: 0 5px;
   border: none;
   border-radius: 3px;
   background-color: var(--main-background);
@@ -45,4 +53,15 @@
   font-size: medium;
   font-weight: bold;
   cursor: pointer;
+}
+
+@media screen and (max-width: 1360px) {
+    .signup-inner-bar {
+        display: grid;
+        grid-auto-flow: row;
+        gap: 10px;
+        justify-self: center;
+        align-items: center;
+        margin: 10px 0;
+    }
 }

--- a/src/styles/Waitlist.css
+++ b/src/styles/Waitlist.css
@@ -1,6 +1,6 @@
 @import url(colors.css);
 
-.signup-bar {
+.waitlist-bar {
     position: fixed;
     top: 0;
     left: 0;
@@ -11,12 +11,12 @@
     box-sizing: border-box;
     z-index: 9999;
 }
-.signup-spacer {
+.waitlist-spacer {
     display: grid;
     grid-template-columns: 1fr auto 1fr;
     justify-items: center;
  }
-.signup-inner-bar {
+.waitlist-inner-bar {
     display: grid;
     grid-auto-flow: column;
     gap: 50px;
@@ -24,19 +24,19 @@
     align-items: center;
     margin: 10px 0;
 }
-.signup-description {
+.waitlist-description {
   margin: 0;
   font-size: larger;
 }
 
-.signup-form {
+.waitlist-form {
   display: grid;
   grid-template-columns: 1fr auto;
   align-items: center;
   margin: 0;
 }
 
-.signup-form input[type="email"] {
+.waitlist-form input[type="email"] {
   min-width: 200px;
   padding: 10px;
   border: none;
@@ -44,7 +44,7 @@
   font-size: medium;
 }
 
-.signup-form button[type="submit"] {
+.waitlist-form button[type="submit"] {
   margin: 0 5px;
   border: none;
   border-radius: 3px;
@@ -56,7 +56,7 @@
 }
 
 @media screen and (max-width: 1360px) {
-    .signup-inner-bar {
+    .waitlist-inner-bar {
         display: grid;
         grid-auto-flow: row;
         gap: 10px;


### PR DESCRIPTION
- Move early access signup to top of landing page. Earlier it was under /waitlist route only
- Move waitlist into component instead of standalone page. 
   Still keep /waitlist route available for direct sharing but not exposed via navigation bar
- Request only email address to signup, no need to fill users industry to signup
- Share link Google survey after early access signup complete
   The short survey currenty contains 3 questions including users industry