### PR TITLE
[Account Creation] Create pages that allow the user to initialize their account

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,12 @@ import NavBar from './NavBar';
 import './styles/App.css';
 import Home from './pages/Home';
 import About from './pages/About';
-import Waitlist from './components/Waitlist';
+import Invited from './pages/Invited';
+import Login from './pages/Login';
 
-import { ConfigProvider } from 'antd';
+import { ConfigProvider, Layout } from 'antd';
+
+const { Content } = Layout;
 
 import {
 	BrowserRouter,
@@ -25,21 +28,28 @@ function App() {
 						}
 					}
 				}>
-
 				<BrowserRouter>
-					<NavBar />
-					<Routes>
-						<Route path="/" element={<Home />} />
-						<Route path="/about" element={<About />} />
-						<Route path="/waitlist" element={<Waitlist />} />
-					</Routes>
+					<Layout>
+						<Layout style={{ padding: 0, background: "#fff" }}>
+							<NavBar />
+							<Content>
+								<Routes>
+									<Route path="/" element={<Home />} />
+									<Route path="/about" element={<About />} />
+									<Route path="/invited/:inviteId" element={<Invited />} />
+									<Route path="/login" element={<Login />} />
+								</Routes>
+							</Content>
+							<footer className="footer-container">
+								<img src='https://raw.githubusercontent.com/khoj-ai/landing-page/master/public/footer_garden.svg' className='footer-garden' alt='footer-garden' />
+								<p className='footer-text'>
+									Designed with ❤️ by Debankon.<br />Developed with 🥵 by Saba and Debanjum.
+								</p>
+							</footer>
+						</Layout>
+					</Layout>
 				</BrowserRouter>
-				<footer className="footer-container">
-					<img src='https://raw.githubusercontent.com/khoj-ai/landing-page/master/public/footer_garden.svg' className='footer-garden' alt='footer-garden' />
-					<p className='footer-text'>
-						Designed with ❤️ by Debankon.<br />Developed with 🥵 by Saba and Debanjum.
-					</p>
-				</footer>
+
 			</ConfigProvider>
 		</div>
   )	;

--- a/src/NavBar.tsx
+++ b/src/NavBar.tsx
@@ -1,19 +1,35 @@
-import { Link, Outlet } from "react-router-dom";
+import { Link } from "react-router-dom";
 import './styles/NavBar.css';
 import Waitlist from "./components/Waitlist";
+import { checkAuthentication } from "./common/auth";
+import { useState } from "react";
+import NavMenu from "./NavMenu";
 
 export default function NavBar() {
+    const [authenticated, setAuthenticated] = useState(false);
+
+    async function isAuth() {
+        const auth = await checkAuthentication();
+        setAuthenticated(auth);
+    }
+
+    if (!authenticated) {
+        isAuth().catch((_) => {
+            setAuthenticated(false);
+        });
+    }
+
     return (
         <nav className="navBar">
             <section className="navSection">
-                <Waitlist />
+                {!authenticated && <Waitlist />}
+                <NavMenu />
                 <div className="navLogo">
                     <Link to="/">
                         <img className='khoj-logo' src="https://raw.githubusercontent.com/khoj-ai/landing-page/master/public/khoj_lantern_logo.svg" alt="Khoj" />
                     </Link>
                 </div>
             </section>
-            <Outlet />
         </nav>
     );
 }

--- a/src/NavMenu.tsx
+++ b/src/NavMenu.tsx
@@ -70,7 +70,7 @@ export default function NavMenu() {
         authAction,
         {
             label: (
-                <a href="https://github.com/debanjum/khoj#Setup" target="_blank" rel="noopener noreferrer">
+                <a href="https://github.com/khoj-ai/khoj#Setup" target="_blank" rel="noopener noreferrer">
                     Self-Host
                 </a>
                 ),

--- a/src/NavMenu.tsx
+++ b/src/NavMenu.tsx
@@ -56,7 +56,7 @@ export default function NavMenu() {
 
     const loginItem = {
         label: (
-            <a href="/login" target="_blank" rel="noopener noreferrer">
+            <a href="/login" target="_blank">
                 Login
             </a>
         ),
@@ -70,7 +70,7 @@ export default function NavMenu() {
         authAction,
         {
             label: (
-                <a href="https://github.com/khoj-ai/khoj#Setup" target="_blank" rel="noopener noreferrer">
+                <a href="https://github.com/khoj-ai/khoj#Setup" target="_blank">
                     Self-Host
                 </a>
                 ),
@@ -79,7 +79,7 @@ export default function NavMenu() {
         },
         {
             label: (
-                <a href="/about" target="_blank" rel="noopener noreferrer">
+                <a href="/about" target="_blank">
                     About
                 </a>
                 ),
@@ -120,7 +120,7 @@ export default function NavMenu() {
         });
         items.push({
             label: (
-                <a href={KHOJ_LINK} target="_blank" rel="noopener noreferrer">
+                <a href={KHOJ_LINK} target="_blank">
                     Go
                 </a>
                 ),

--- a/src/NavMenu.tsx
+++ b/src/NavMenu.tsx
@@ -1,0 +1,145 @@
+import './styles/App.css';
+import { useState } from 'react';
+
+import { Menu } from 'antd';
+
+import {
+	UserOutlined,
+	SettingOutlined,
+	CloudDownloadOutlined,
+} from '@ant-design/icons';
+import type { MenuProps } from 'antd';
+
+import { KHOJ_LINK, APIURL } from './common/constants';
+import { checkAuthentication } from './common/auth';
+
+export default function NavMenu() {
+    function logout() {
+        const csrfToken = document.cookie.split('; ').find(row => row.startsWith('csrftoken'))?.split('=')[1];
+        fetch(`${APIURL}/auth/logout/`, {
+            method: 'POST',
+            credentials: 'include',
+            headers: {
+                'X-CSRFToken': csrfToken || '',
+            },
+            }).then((res) => {
+                if (res.status === 200) {
+                    window.location.href = '/';
+            }}).catch((error) => {
+                console.log("Logout failed");
+            }
+        );
+    }
+
+    const [authenticated, setAuthenticated] = useState(false);
+
+    async function isAuth() {
+        const auth = await checkAuthentication();
+        setAuthenticated(auth);
+    }
+
+    if (!authenticated) {
+        isAuth().catch((error) => {
+            setAuthenticated(false);
+        });
+    }
+
+    const logoutItem = {
+        label: (
+            <a onClick={logout}>
+                Logout
+            </a>
+        ),
+        key: 'logout',
+        icon: <UserOutlined />,
+    };
+
+    const loginItem = {
+        label: (
+            <a href="/login" target="_blank" rel="noopener noreferrer">
+                Login
+            </a>
+        ),
+        key: 'login',
+        icon: <UserOutlined />,
+    };
+
+    const authAction = authenticated ? logoutItem : loginItem;
+
+    const items: MenuProps['items'] = [
+        authAction,
+        {
+            label: (
+                <a href="https://github.com/debanjum/khoj#Setup" target="_blank" rel="noopener noreferrer">
+                    Self-Host
+                </a>
+                ),
+            key: 'selfhost',
+            icon: <CloudDownloadOutlined />,
+        },
+        {
+            label: (
+                <a href="/about" target="_blank" rel="noopener noreferrer">
+                    About
+                </a>
+                ),
+            key: 'about',
+        },
+    ];
+
+    if (authenticated) {
+        items.push({
+            label: 'Manage Khoj',
+            key: 'SubMenu',
+            icon: <SettingOutlined />,
+            children: [
+            {
+                type: 'group',
+                label: 'Settings',
+                children: [
+                {
+                    label: 'Update Configuraiton',
+                    key: 'setting:1',
+                },
+                {
+                    label: 'Search',
+                    key: 'setting:2',
+                },],
+            },
+            {
+                type: 'group',
+                label: 'Subscription',
+                children:
+                [
+                {
+                    label: 'Manage Billing',
+                    key: 'setting:3',
+                },
+                ],
+            },],
+        });
+        items.push({
+            label: (
+                <a href={KHOJ_LINK} target="_blank" rel="noopener noreferrer">
+                    Go
+                </a>
+                ),
+            key: 'go',
+        })
+    }
+
+
+	const [current, setCurrent] = useState('mail');
+
+	const onClick: MenuProps['onClick'] = (e) => {
+		console.log('click ', e);
+		setCurrent(e.key);
+	};
+  
+
+	return (
+        <div>
+            <Menu onClick={onClick} selectedKeys={[current]} mode="horizontal" items={items} />
+        </div>
+  )	;
+}

--- a/src/NavMenu.tsx
+++ b/src/NavMenu.tsx
@@ -98,7 +98,7 @@ export default function NavMenu() {
                 label: 'Settings',
                 children: [
                 {
-                    label: 'Update Configuraiton',
+                    label: 'Update Configuration',
                     key: 'setting:1',
                 },
                 {

--- a/src/common/auth.ts
+++ b/src/common/auth.ts
@@ -1,0 +1,16 @@
+import { APIURL } from "./constants"
+
+export async function checkAuthentication() {
+    try {
+        const response = await fetch(`${APIURL}/auth/check/`, {
+            method: "GET",
+            credentials: "include",
+        });
+        if (response.status === 200) {
+            return true;
+        }
+        return false;
+    } catch (error) {
+        return false;
+    }
+}

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,3 @@
+export const APIURL = process.env.NODE_ENV == 'production' ? "https://lantern.khoj.dev" : 'http://localhost:5000';
+export const DISCORD_LINK = "https://discord.gg/fP89zSJb";
+export const KHOJ_LINK = process.env.NODE_ENV == 'production' ? "https://lantern.khoj.dev" : 'http://localhost:5000';

--- a/src/components/Waitlist.tsx
+++ b/src/components/Waitlist.tsx
@@ -4,6 +4,8 @@ import { Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { Input, SubmitButton } from 'formik-antd'
 import { useState } from 'react';
+import { APIURL } from '../common/constants';
+import { useLocation } from 'react-router-dom';
 
 
 export function Waitlist() {
@@ -13,7 +15,12 @@ export function Waitlist() {
 		email: Yup.string().email('Invalid email').required('Required'),
 	});
 
-	const APIURL = process.env.NODE_ENV == 'production' ? "https://lantern.khoj.dev" : 'http://localhost:5000';
+    // Get the path of the URL
+    const location = useLocation();
+    if (location.pathname.includes('invited') || location.pathname.includes('login')) {
+        return null;
+    }
+
 
 	return (
 			<div className='waitlist-bar'>
@@ -41,7 +48,7 @@ export function Waitlist() {
 									return response.json()
 							})
 							.catch((error) => {
-								console.log(error);
+								setFailed(true);
 							});
 							setSubmitting(false);
 						}, 400);
@@ -63,6 +70,7 @@ export function Waitlist() {
 								<p className="waitlist-description">Get an early invite to Khoj cloud</p>
 								<Form className='waitlist-form'>
 									<Input
+										disabled={success}
 										type="email"
 										name="email"
 										placeholder="Enter your email address"
@@ -71,7 +79,7 @@ export function Waitlist() {
 										value={values.email}
 										status={(errors.email && touched.email) ? "error" : ""}
 									/>
-									<SubmitButton size='large' disabled={false} loading={isSubmitting} style={{padding: '9px'}}>
+									<SubmitButton size='large' disabled={success} loading={isSubmitting} style={{padding: '9px'}}>
 										Join
 									</SubmitButton>
 								</Form>
@@ -81,7 +89,7 @@ export function Waitlist() {
 					)}
 				</Formik>
 				{
-					success ? <p>Thanks for requesting early access 🌈! We'll reach out shortly. Until then take this short <a href="https://forms.gle/FRe6XPkcgkKsVbzC9">survey</a> to guide our feature development roadmap.</p> : null
+					success ? <p>✅ Thanks for requesting early access! We'll reach out shortly. Until then, take this short <a className='inline-link-light' href="https://forms.gle/FRe6XPkcgkKsVbzC9">survey</a>.</p> : null
 				}
 				{
 					failed ? <p>Woops, that did not go as expected 😵‍💫. Try again or contact <a href="mailto:team@khoj.dev">team@khoj.dev</a></p> : null

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,4 +1,5 @@
 import '../styles/About.css';
+import { DISCORD_LINK } from '../common/constants';
 
 export default function About() {
     return (
@@ -67,7 +68,7 @@ export default function About() {
                             </p>
                             <ul className='content'>
                                 <li className='content'>
-                                    <a className="inline-link-light" href="https://discord.gg/5UhUG5fh">Discord</a>
+                                    <a className="inline-link-light" href={DISCORD_LINK}>Discord</a>
                                     <p className='content'>This is best if you're looking to learn more about the product and participate in discussions.</p>
                                 </li>
                                 <li className='content'>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import { GithubIcon, DiscordIcon, EmacsIcon, ObsidianIcon } from '../components/
 import Waitlist from '../components/Waitlist';
 import Icon from '@ant-design/icons';
 import { TypeAnimation } from 'react-type-animation';
+import { DISCORD_LINK } from '../common/constants';
 
 export function Home() {
 	const [showControls, setShowControls] = useState(false);
@@ -84,7 +85,7 @@ export function Home() {
 							style={{borderRadius: '4px'}}
 							ghost
 							icon={<Icon component={DiscordIcon} />}
-							href="https://discord.gg/fP89zSJb">
+							href={DISCORD_LINK}>
 								Join us on Discord
 						</Button>
 					</div>
@@ -126,7 +127,7 @@ export function Home() {
                                 This will help people who want to self-host Khoj but without the hassle of managing their Python versions and dependencies.
                             </p>
                             <p className='product-description-subcomponent-light'>
-                                We're in the thick of building and improving Khoj, and <b>we want to hear from you.</b> Join the <b><a className='inline-link-light' href="https://discord.gg/fP89zSJb">Discord</a></b> to voice your opinions and tell us which features you'd like us to prioritize.
+                                We're in the thick of building and improving Khoj, and <b>we want to hear from you.</b> Join the <b><a className='inline-link-light' href={DISCORD_LINK}>Discord</a></b> to voice your opinions and tell us which features you'd like us to prioritize.
                             </p>
 							<Waitlist />
 						</div>

--- a/src/pages/Invited.tsx
+++ b/src/pages/Invited.tsx
@@ -1,0 +1,204 @@
+import { useState, useRef } from 'react';
+import { Input, SubmitButton } from 'formik-antd'
+import { Link } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
+import { APIURL, DISCORD_LINK } from '../common/constants';
+import { Form, Formik } from 'formik';
+import * as Yup from 'yup';
+
+
+import '../styles/Invited.css';
+
+enum Status {
+	Loading,
+	ValidInvite,
+	Success,
+	NotFound,
+	Used,
+	Oops,
+}
+
+interface ValidInviteResponse {
+	email: string;
+}
+
+interface SetPasswordResponse {
+	errors: string[];
+}
+
+
+export function Invited() {
+	const { inviteId } = useParams<{ inviteId: string }>();
+	const navigate = useNavigate();
+	const [status, setStatus] = useState<Status>(Status.Loading);
+	const [email, setEmail] = useState<string>('');
+	const [checkedInvite, setCheckedInvite] = useState<boolean>(false);
+	const PasswordSchema = Yup.object().shape({
+		password: Yup.string().required('Required').min(8, 'Must be 8 characters or more'),
+		confirmPassword: Yup.string().required('Required').oneOf([Yup.ref('password')], 'Passwords must match'),
+	});
+
+	if (inviteId === undefined || inviteId === null || inviteId === '') {
+		navigate('/');
+	} else {
+		if (!checkedInvite) {
+			fetch(`${APIURL}/beta/invite/${inviteId}/`, {
+				method: 'GET',
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				})
+				.then(response => 
+					{
+						if (response.status === 404) {
+							setStatus(Status.NotFound);
+						} else if (response.status === 200) {
+							setStatus(Status.ValidInvite);
+						} else if (response.status === 410) {
+							setStatus(Status.Used);
+						} else {
+							setStatus(Status.Oops);
+						}
+						return response.json();
+					})
+				.then((data: ValidInviteResponse) => {
+					if (data.email !== undefined) {
+						setEmail(data.email);
+					}
+				})
+				.catch((error) => {
+					setStatus(Status.Oops);
+				});
+			setCheckedInvite(true);
+		}
+	}
+
+	function NotFoundComponent() {
+		return (
+			<section className='core-page'>
+				<h2 className='title'>Sorry, looks like that URL isn't valid.</h2>
+				<p className='invited-title'>Your invite link is invalid. Please contact the person who invited you or message the team on <a className='inline-link-light' href={DISCORD_LINK}>Discord</a> for support.</p>
+			</section>
+		);
+	}
+
+	function SetPasswordComponent() {
+		return (
+			<section className='core-page'>
+				<h2 className='title'>Welcome to the platform! We're psyched to have you here.</h2>
+				<p className='invited-title'>Please set a password for your account.</p>
+				<p className='invited-title'><b>{email}</b></p>
+				<Formik
+					initialValues={{ password: '', confirmPassword: '' }}
+					validationSchema={PasswordSchema}
+					onSubmit={(values, { setSubmitting, setErrors },) => {
+						setTimeout(() => {
+							fetch(`${APIURL}/beta/invite/${inviteId!}/set-password/`, {
+								method: 'POST',
+								headers: {
+									'Content-Type': 'application/json',
+								},
+								body: JSON.stringify({
+									password: values.password,
+								})
+							})
+								.then(response =>
+									{
+										if (response.status === 200) {
+											setStatus(Status.Success);
+											return response;
+										} else if (response.status === 410) {
+											setStatus(Status.Used);
+										} else if(response.status == 400) {
+											setStatus(Status.ValidInvite);
+										} else {
+											setStatus(Status.Oops);
+										}
+										return response.json();
+									})
+									.then((data: SetPasswordResponse) => {
+										if (data.errors) {
+											setErrors({confirmPassword: data.errors[0]});
+										}
+									})
+								.catch((error) => {
+									setStatus(Status.Oops);
+							});
+							setSubmitting(false);
+						}, 400);
+					}}
+				>
+					{({ isSubmitting, errors }) => (
+						<Form className='invited-form'>
+							<Input.Password
+								id="password"
+								name="password"
+								placeholder='Password'
+								style={{ marginBottom: '1rem' }}
+							/>
+							<div className='error-message'>{errors.password}</div>
+							<Input.Password
+								id="confirmPassword"
+								name="confirmPassword"
+								placeholder='Confirm Password'
+								style={{ marginBottom: '1rem' }}
+							/>
+							<div className='error-message'>{errors.confirmPassword}</div>
+							<SubmitButton size='large' type="primary" disabled={isSubmitting}>
+								Set Password
+							</SubmitButton>
+						</Form>
+					)}
+				</Formik>
+			</section>
+		)
+	}
+
+	function UsedComponent() {
+		return (
+			<section className='core-page'>
+				<h2 className='title'>Looks like that invite is already claimed.</h2>
+				<p className='invited-title'>Click <a className='inline-link-light' href="/login">here to</a> login. Contact us at <a className='inline-link-light' href='mailto:team@khoj.dev'>team@khoj.dev</a> or on <a className='inline-link-light' href={DISCORD_LINK}>Discord</a> for support.</p>
+			</section>
+		)
+	}
+
+	function LoadingComponent() {
+		return (
+			<section className='core-page'>
+				<h2 className='title'>Loading...</h2>
+			</section>
+		)
+	}
+
+	function OopsComponent() {
+		return (
+			<section className='core-page'>
+				<h2 className='title'>Oops, something went wrong.</h2>
+				<p className='invited-title'>Please contact the team on at <a className='inline-link-light' href='mailto:team@khoj.dev'>team@khoj.dev</a> <a className='inline-link-light' href={DISCORD_LINK}>Discord</a> for support.</p>
+			</section>
+		)
+	}
+
+	function SuccessComponent() {
+		return (
+			<section className='core-page'>
+				<h2 className='title'>Success! 🎉</h2>
+				<p className='invited-title'>Your password has been set. Click <a className='inline-link-light' href="/login">here to</a> login.</p>
+			</section>
+		)
+	}
+
+	return (
+		<>
+			{status === Status.Loading && <LoadingComponent />}
+			{status === Status.ValidInvite && <SetPasswordComponent />}
+			{status === Status.NotFound && <NotFoundComponent />}
+			{status === Status.Used && <UsedComponent />}
+			{status === Status.Oops && <OopsComponent />}
+			{status === Status.Success && <SuccessComponent />}
+		</>
+	);
+}
+
+export default Invited;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react';
+import { Input, SubmitButton } from 'formik-antd'
+import { useNavigate } from "react-router-dom";
+import { APIURL, DISCORD_LINK } from '../common/constants';
+import { Form, Formik } from 'formik';
+import * as Yup from 'yup';
+
+
+import '../styles/Login.css';
+
+enum Status {
+	Success,
+	Unauthorized,
+	Oops,
+    Init,
+}
+
+
+export function Login() {
+	const navigate = useNavigate();
+	const [status, setStatus] = useState<Status>(Status.Init);
+	const LoginSchema = Yup.object().shape({
+        email: Yup.string().email('Invalid email').required('Required'),
+        password: Yup.string().required('Required'),
+	});
+
+	function LoginComponent() {
+		return (
+			<section className='core-page'>
+				<h2 className='title'>Welcome back!</h2>
+				<Formik
+					initialValues={{ email: '', password: '' }}
+					validationSchema={LoginSchema}
+					onSubmit={(values, { setSubmitting }) => {
+						setTimeout(() => {
+                            const csrfToken = document.cookie.split('; ').find(row => row.startsWith('csrftoken'))?.split('=')[1];
+							fetch(`${APIURL}/auth/login/`, {
+								method: 'POST',
+                                credentials: 'include',
+								headers: {
+									'Content-Type': 'application/json',
+                                    'X-CSRFToken': csrfToken || '',
+								},
+								body: JSON.stringify({
+                                    email: values.email,
+									password: values.password,
+								})
+                            })
+								.then(response =>
+									{
+										console.log(response);
+										console.log(response.status);
+                                        if (response.status === 200) {
+                                            navigate('/');
+                                        } else if (response.status === 404) {
+                                            setStatus(Status.Unauthorized);
+                                        } else {
+                                            setStatus(Status.Oops);
+                                        }
+
+										return response.json()
+									})
+								.catch((error) => {
+									console.log(error);
+							});
+							setSubmitting(false);
+						}, 400);
+					}}
+				>
+					{({ isSubmitting, errors }) => (
+						<Form className='invited-form'>
+							<Input
+								id="email"
+								name="email"
+								placeholder='email'
+								style={{ marginBottom: '1rem' }}
+							/>
+							<div className='error-message'>{errors.email}</div>
+							<Input.Password
+								id="password"
+								name="password"
+								placeholder='password'
+								style={{ marginBottom: '1rem' }}
+							/>
+							<div className='error-message'>{errors.password}</div>
+							<SubmitButton size='large' type="primary" disabled={isSubmitting}>
+								Login
+							</SubmitButton>
+						</Form>
+					)}
+				</Formik>
+			</section>
+		)
+	}
+
+	function UnauthorizedComponent() {
+		return (
+			<section className='core-page'>
+				<p className='invited-title'>Sorry, looks like those credentials are invalid.</p>
+			</section>
+		)
+	}
+
+	function OopsComponent() {
+		return (
+			<section className='core-page'>
+				<h2 className='title'>Oops, something went wrong.</h2>
+				<p className='invited-title'>Please contact the team on <a className='inline-link-light' href={DISCORD_LINK}>Discord</a> for support.</p>
+			</section>
+		)
+	}
+
+
+	return (
+		<>
+            <LoginComponent />
+            {status === Status.Unauthorized && <UnauthorizedComponent />}
+            {status === Status.Oops && <OopsComponent />}
+
+		</>
+	);
+}
+
+export default Login;

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -40,13 +40,12 @@ footer.footer-container {
   background-color: var(--mild-sun);
 }
 p.footer-text {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--reader);
   font-weight: normal;
   font-size: small;
 }
 
 img.footer-garden {
-    padding: 0 7%;
     background: linear-gradient(
         to bottom,
         var(--light) 0%,

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -1,4 +1,5 @@
 @import 'colors.css';
+@import 'fonts.css';
 
 div.camping-block {
     background-color: var(--mild-sun);
@@ -29,7 +30,7 @@ div.product-description {
     display: grid;
     grid-template-columns: 1fr;
     justify-content: space-around;
-    font-family: 'EB Garamond', serif;
+    font-family: var(--reader);
     font-size: medium;
 }
 
@@ -137,7 +138,7 @@ div.production-description-subcomponent-light {
 
 h2.production-description-subcomponent {
     text-align: left;
-    font-family: 'DM Serif Display', serif;
+    font-family: var(--impact);
     margin: 0;
 }
 
@@ -159,7 +160,7 @@ div.typing-components {
     text-align: center;
     white-space: pre-line;
     font-size: x-large;
-    font-family: 'EB Garamond', serif;
+    font-family: var(--reader);
     margin-top: 8px;
     margin-bottom: 32px;
 }

--- a/src/styles/Invited.css
+++ b/src/styles/Invited.css
@@ -1,0 +1,23 @@
+@import 'fonts.css';
+@import 'colors.css';
+
+form.invited-form {
+    margin: 0 35%;
+}
+
+p.invited-title {
+    font-family: var(--reader);
+    font-size: var(--subtitle-size);
+}
+
+input#password, input#confirmPassword {
+    font-family: var(--reader);
+    font-size: var(--subtitle-size);
+}
+
+div.error-message {
+    font-family: var(--reader);
+    color: var(--error-color);
+    text-align: left;
+    margin: 0 0 1rem 0;
+}

--- a/src/styles/Login.css
+++ b/src/styles/Login.css
@@ -1,0 +1,7 @@
+@import 'colors.css';
+@import 'fonts.css';
+
+input#email, input#password {
+    font-family: var(--reader);
+    font-size: var(--subtitle-size);
+}

--- a/src/styles/NavBar.css
+++ b/src/styles/NavBar.css
@@ -41,7 +41,7 @@ div.navLogo {
 }
 
 img.khoj-logo {
-    width: min(90vw, 550px);
+    width: min(70vw, 550px);
     padding: 10px 0;
 }
 

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -4,4 +4,5 @@
     --mild-sun: #f9f5de;
     --light: #fff;
     --calm-water-accent: #6fa7ab;
+    --error-color: #ff0000;
 }

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -1,4 +1,6 @@
 :root {
     --title-size: 36px;
     --subtitle-size: 24px;
+    --impact: 'DM Serif Display', serif;
+    --reader: 'EB Garamond', serif;
 }


### PR DESCRIPTION
## Incoming
- Setup infrastructure that allows users to set up their accounts once they're invited to sign on to Khoj from the waitlist
- Add an initial orientation page called `Invited` where the user first configures their password. Then, navigate them to `Login.tsx`, where they can Login and store their credentials for the first time
- For all calls, add relevant headers and settings to include the CSRF token
- Add a navigation menu that the user can easily leverage to navigate the site and get to their Khoj instance!!

| Logged In | Logged Out |
|-|-|
|<img width="1367" alt="Screenshot 2023-06-21 at 7 08 20 PM" src="https://github.com/khoj-ai/landing-page/assets/65192171/132c45cc-3bdc-4b4d-9723-4a3c8ac2ad16">|<img width="1363" alt="Screenshot 2023-06-21 at 7 08 53 PM" src="https://github.com/khoj-ai/landing-page/assets/65192171/769e1b8a-907d-4b9e-a5b5-089d64df36f1">|

|Invited|Login|
|-|-|
|<img width="852" alt="Screenshot 2023-06-21 at 7 10 28 PM" src="https://github.com/khoj-ai/landing-page/assets/65192171/91bae050-b8fa-4f2b-9bce-04ac0589e603">|<img width="871" alt="Screenshot 2023-06-21 at 7 11 22 PM" src="https://github.com/khoj-ai/landing-page/assets/65192171/ee560a12-7c80-4ff8-847c-c41032dded01">|


Need to merge https://github.com/khoj-ai/lantern/pull/7 before this one merges. Closes https://github.com/khoj-ai/landing-page/issues/10.
