### PR TITLE
added dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+**/node_modules/
+**/.git
+**/README.md
+**/LICENSE
+**/.vscode
+**/npm-debug.log
+**/coverage
+**/.env
+**/.editorconfig
+**/.aws
+**/dist


### PR DESCRIPTION
Adding the .dockerignore reduces the docker build time.
These suggestions are from [ node best practices ] (https://github.com/goldbergyoni/nodebestpractices/blob/master/sections/docker/docker-ignore.md) good default .dockerignore for Node.js
![Screenshot 2023-08-08 at 08 17 32](https://github.com/khoj-ai/landing-page/assets/51520018/908ab706-7656-47cc-b82e-7d3295265385)
