### PR TITLE
changed instances of flex to grid

### DIFF
--- a/src/styles/About.css
+++ b/src/styles/About.css
@@ -27,11 +27,6 @@ h2.article-title {
 }
 
 @media screen and (max-width: 760px) {
-    div.content-sections {
-        display: flex;
-        flex-direction: column;
-    }
-
     div.article {
         margin: 0 1rem;
     }

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -5,8 +5,8 @@
 .App {
   text-align: center;
   min-height: 100vh;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr;
 }
 
 body {

--- a/src/styles/Invited.css
+++ b/src/styles/Invited.css
@@ -21,3 +21,9 @@ div.error-message {
     text-align: left;
     margin: 0 0 1rem 0;
 }
+
+@media screen and (max-width: 768px) {
+    form.invited-form {
+        margin: 0 10%;
+    }
+}

--- a/src/styles/Login.css
+++ b/src/styles/Login.css
@@ -6,20 +6,13 @@ input#login-email, input#login-password {
     font-size: var(--subtitle-size);
 }
 
-.login-page{
+.login-page {
     align-items: center;
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: 1fr;
     padding-top: 40px;
 }
 
 input#login-email{
     margin-top: 20px;
-    max-width: 442px;
-    width: calc(70vw + 42px);
-}
-
-input#login-password {
-    width: 70vw;
-    max-width: 400px;
 }

--- a/src/styles/Login.css
+++ b/src/styles/Login.css
@@ -20,6 +20,6 @@ input#login-email{
 }
 
 input#login-password {
-    max-width: 400px;
     width: 70vw;
+    max-width: 400px;
 }


### PR DESCRIPTION
Closes issue #30 

Changed instances of flex box to grid for better maintainability.

The only place where I did not change flex to grid was in Login.css. This was because under grid display, the password input field would become extremely long compared to the email input field. This probably has to do with the styling properties of the <Input.Password> element from 'formik-antd'. It is a span wrapping the password's input element, and the span has css styling specificially stating to not override the css styling for it. For that reason I chose to leave the flex display in Login.css since it does make the styling look similar between the 2 input elements in the Login.tsx page. 

Please let me know if you'd like me to try and override the formik-antd default styling for the Input.Password element.

Thanks!