### PR TITLE
Add posthog support to the landing page

### DIFF
--- a/.github/workflows/dockerize.yml
+++ b/.github/workflows/dockerize.yml
@@ -34,3 +34,5 @@ jobs:
         with:
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ env.DOCKER_IMAGE_TAG }}
+          build-args: |
+            POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Build Stage
 FROM node:current-alpine as build
 WORKDIR /app
+ARG POSTHOG_API_KEY
+ENV REACT_APP_POSTHOG_API_KEY=$POSTHOG_API_KEY
 COPY package.json .
 COPY yarn.lock .
 RUN yarn install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   landing:
     build:
       context: .
+      args:
+        - POSTHOG_API_KEY=${POSTHOG_API_KEY}
     ports:
       - "3000:80"
     volumes:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "formik": "^2.4.1",
     "formik-antd": "^2.0.4",
     "moment": "^2.29.4",
+    "posthog-js": "^1.83.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.11.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,15 @@ import {
 	Routes,
 } from "react-router-dom";
 
+import posthog from 'posthog-js'
+
+const posthogAPIKey = process.env.REACT_APP_POSTHOG_API_KEY;
+
+if (posthogAPIKey !== undefined) {
+	posthog.init(posthogAPIKey, { api_host: 'https://app.posthog.com' });
+}
+
+
 function App() {
 	return (
 		<div className="App">

--- a/yarn.lock
+++ b/yarn.lock
@@ -4801,6 +4801,11 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fflate@^0.4.1:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.4.8.tgz#f90b82aefbd8ac174213abb338bd7ef848f0f5ae"
+  integrity sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -7748,6 +7753,13 @@ postcss@^8.3.5, postcss@^8.4.21, postcss@^8.4.23, postcss@^8.4.4:
     nanoid "^3.3.6"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
+
+posthog-js@^1.83.0:
+  version "1.83.0"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.83.0.tgz#e13d114922f863f4bfbf7c7cc4e11dc194139a91"
+  integrity sha512-3dp/yNbRCYsOgvJovFUMCLv9/KxnwmGBy5Ft27Q7/rbW++iJXVR64liX7i0NrXkudjoL9j1GW1LGh84rV7kv8Q==
+  dependencies:
+    fflate "^0.4.1"
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
# Incoming
- Add PostHog support to the landing page. This will be useful for collecting metrics about visit trends and for seeing how we can improve our landing page over time. It will also allow us to utilize the PostHog Surveys feature.
